### PR TITLE
Minor markdown fix for the handlebar docs

### DIFF
--- a/docs/plugins/handlebars.md
+++ b/docs/plugins/handlebars.md
@@ -1,7 +1,6 @@
 # Handlebars
 _[@vituum/vite-plugin-handlebars](https://github.com/vituum/vite-plugin-handlebars)_
 ```handlebars
-```twig
 <ul id="navigation">
     {{#each navigation as |item|}}
         <li>{{ item }}</li>


### PR DESCRIPTION
I removed extra markdown syntax on the handlebars example probably left in when copied from the twig example